### PR TITLE
Replace out of dated function with vital module

### DIFF
--- a/autoload/deoplete_lamp.vim
+++ b/autoload/deoplete_lamp.vim
@@ -1,4 +1,5 @@
 let s:Promise = vital#lamp#import('Async.Promise')
+let s:Position = vital#lamp#import('VS.LSP.Position')
 
 let s:request = {}
 
@@ -135,7 +136,7 @@ function! s:get_complete_position() abort
     let l:chars += l:server.capability.get_completion_trigger_characters()
   endfor
 
-  let l:position = lamp#protocol#position#get()
+  let l:position = s:Position.cursor()
   let l:before_line = substitute(lamp#view#cursor#get_before_line(), '\w*$', '', 'g')
   let l:position.character = strlen(l:before_line)
   if index(l:chars, l:before_line[-1 : -1]) == -1


### PR DESCRIPTION
I got the follow error when using `deoplete`, `vim-lamp` and `deoplete-lamp`.

```
pynvim.api.common.NvimError: Vim(let):E117: Unknown function: lamp#protocol#position#get
Error from lamp: Vim(let):E117: Unknown function: lamp#protocol#position#get.  Use :messages / see above for error details.
```

I find that `lamp#protocol#position#get` is removed from https://github.com/hrsh7th/vim-lamp and replaced with vital module.

Please help review this PR. Thanks.

